### PR TITLE
Issue #36. Fixed [PATCH /user/deleteProfilePicture] endpoint always returning 401 Unauthorized.

### DIFF
--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -312,7 +312,7 @@ public class UserController {
     })
     @PatchMapping(path = "/deleteProfilePicture")
     public ResponseEntity<HttpStatus> deleteUserProfilePicture(
-        @ApiIgnore @AuthenticationPrincipal Principal principal) {
+        @ApiIgnore Principal principal) {
         String email = principal.getName();
         userService.deleteUserProfilePicture(email);
         return ResponseEntity.status(HttpStatus.OK).build();


### PR DESCRIPTION
Removed @AuthenticationPrincipal before Principal principal.
<img width="1288" height="703" alt="image" src="https://github.com/user-attachments/assets/fa67f9df-9263-4583-8fcd-35a67199b9ab" />
