### PR TITLE
Issue #22. Fixed [PUT /user/updateUserLastActivityTime/{date}] endpoint returning 401 Unauthorized when 403 Forbidden is needed.

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -92,10 +92,16 @@ public class SecurityConfig {
                         new AccessTokenAuthenticationFilter(jwtTool, authenticationManager(), userService),
                         UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(exception -> exception
-                        .authenticationEntryPoint((req, resp, exc) -> resp.sendError(
-                                SC_UNAUTHORIZED, "Authorize first."))
-                        .accessDeniedHandler((req, resp, exc) -> resp.sendError(
-                                SC_FORBIDDEN, "You don't have authorities.")))
+                        .authenticationEntryPoint((req, resp, e) -> {
+                            resp.setStatus(SC_UNAUTHORIZED);
+                            resp.setContentType("application/json");
+                            resp.getWriter().write("{\"status\":401,\"message\":\"Authorize first.\"}");
+                        })
+                        .accessDeniedHandler((req, resp, e) -> {
+                            resp.setStatus(SC_FORBIDDEN);
+                            resp.setContentType("application/json");
+                            resp.getWriter().write("{\"status\":403,\"message\":\"You don't have authorities.\"}");
+                        }))
                 .authorizeHttpRequests(req -> req
                         .requestMatchers("/static/css/**", "/static/img/**").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
@@ -165,10 +171,11 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PUT,
                                 "/ownSecurity/changePassword",
                                 "/user/profile",
-                                "/user/{id}/updateUserLastActivityTime/{date}",
                                 "/user/language/{languageId}",
                                 "/user/employee-email")
                         .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
+                        .requestMatchers(HttpMethod.PUT, "/user/updateUserLastActivityTime/**")
+                        .hasAnyRole(ADMIN)
                         .requestMatchers(HttpMethod.PUT,
                                 "/user/edit-authorities",
                                 "/user/authorities",


### PR DESCRIPTION
<img width="853" height="105" alt="image" src="https://github.com/user-attachments/assets/b28678ef-77e4-4ed1-9b42-ec743ae4167b" />
Під час обробки AccessDeniedException використовувався `resp.sendError(403, ...)`. Це викликало error-dispatch у контейнері (форвард на `/error`). Оскільки `/error` був захищеним, він оброблявся повторно і в результаті клієнт отримував 401 замість 403.


<img width="792" height="268" alt="image" src="https://github.com/user-attachments/assets/2e088399-471e-4dfd-a19a-529284a51284" />

Тепер відправляється JSON 401/403 з повідомленням, замість використання sendError методу.
<img width="1287" height="899" alt="image" src="https://github.com/user-attachments/assets/aff7e4b3-2ff2-42b4-828e-c39dc022b686" />
<img width="1283" height="930" alt="image" src="https://github.com/user-attachments/assets/de1cff99-d092-4e4c-9a94-d9eeb7e04b3f" />

Якщо хочеться залишити sendError метод, то як альтернативу можна дозволити обробку DispatcherType.ERROR, додавши .dispatcherTypeMatchers(DispatcherType.ERROR, DispatcherType.FORWARD).permitAll() всередині .authorizeHttpRequests.
<img width="858" height="70" alt="image" src="https://github.com/user-attachments/assets/856a3aa8-7e57-4021-a88f-b63e41d7fddf" />
