### PR TITLE
Bugfix/update via user management

### DIFF
--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -483,8 +483,13 @@ public class UserController {
     @Operation(summary = "update via UserManagement")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+
+
+
     })
     @PutMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)

--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -481,7 +481,11 @@ public class UserController {
      * @author Orest Mamchuk
      */
     @Operation(summary = "update via UserManagement")
-    @ApiResponses(value = @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED))
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
     @PutMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
     public void updateUserManagement(


### PR DESCRIPTION
Було розширено OpenAPI-документацію методу updateUserManagement, щоб вона описувала всі основні HTTP-відповіді (200, 401, 404)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded API documentation for a public user-management update endpoint to list all possible HTTP responses (200, 400, 401, 403, 404), improving clarity for API consumers.
  * No changes to runtime behavior or request/response payloads; this update strictly enhances the documented outcomes to better set expectations and aid integration and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->