### PR TITLE
Issue #121. Issue #122. Google oauth credentials and initiation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ build/
 .vscode/
 src/main/resources/static/
 src/main/resources/application.properties
+
+### Secrets ###
+.env
+application-secrets.properties

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -86,6 +86,10 @@
             <version>2.1.4</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-web</artifactId>
         </dependency>

--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -20,6 +20,9 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -121,6 +124,7 @@ public class SecurityConfig {
                                 "/ownSecurity/updateAccessToken",
                                 "/ownSecurity/restorePassword",
                                 "/googleSecurity",
+                                "/auth/google",
                                 "/facebookSecurity/generateFacebookAuthorizeURL",
                                 "/facebookSecurity/facebook",
                                 "/user/activatedUsersAmount",
@@ -259,5 +263,10 @@ public class SecurityConfig {
     public GoogleIdTokenVerifier googleIdTokenVerifier() {
         return new GoogleIdTokenVerifier.Builder(new NetHttpTransport(),
                 GsonFactory.getDefaultInstance()).build();
+    }
+
+    @Bean
+    public AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
+        return new HttpSessionOAuth2AuthorizationRequestRepository();
     }
 }

--- a/core/src/main/java/greencity/security/controller/GoogleSecurityController.java
+++ b/core/src/main/java/greencity/security/controller/GoogleSecurityController.java
@@ -1,0 +1,45 @@
+package greencity.security.controller;
+
+import greencity.annotations.ApiLocale;
+import greencity.service.GoogleAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@Validated
+@Slf4j
+public class GoogleSecurityController {
+    private final GoogleAuthService googleAuthService;
+
+    public GoogleSecurityController(GoogleAuthService googleAuthService) {
+        this.googleAuthService = googleAuthService;
+    }
+
+    @Operation(summary = "Redirect to Google consent with CSRF state")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "302", description = "Redirect to Google OAuth URL", headers = {
+                    @Header(name = "Location", description = "Google Authorization URL")
+            }),
+    })
+    @GetMapping("/auth/google")
+    @ApiLocale
+    public ResponseEntity<Void> redirectToGoogleConsent(HttpServletRequest request, HttpServletResponse response) {
+        URI redirectUrl = googleAuthService.generateGoogleAuthRedirectUrl(request, response);
+
+        return ResponseEntity
+                .status(HttpStatus.FOUND)
+                .location(redirectUrl)
+                .build();
+    }
+}

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -1,3 +1,10 @@
 spring.profiles.active=${PROFILE:dev}
 
 springdoc.swagger-ui.doc-expansion=none
+
+spring.config.import=optional:application-secrets.properties
+
+spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8060/auth/google/callback
+spring.security.oauth2.client.registration.google.scope=email,profile,openid
+spring.security.oauth2.client.registration.google.authorization-grant-type=code
+spring.security.oauth2.client.provider.google.authorization-uri=https://accounts.google.com/o/oauth2/v2/auth

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -6,5 +6,6 @@ spring.config.import=optional:application-secrets.properties
 
 spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8060/auth/google/callback
 spring.security.oauth2.client.registration.google.scope=email,profile,openid
-spring.security.oauth2.client.registration.google.authorization-grant-type=code
+spring.security.oauth2.client.registration.google.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.google.response-type=code
 spring.security.oauth2.client.provider.google.authorization-uri=https://accounts.google.com/o/oauth2/v2/auth

--- a/service-api/src/main/java/greencity/service/GoogleAuthService.java
+++ b/service-api/src/main/java/greencity/service/GoogleAuthService.java
@@ -1,0 +1,11 @@
+package greencity.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.net.URI;
+
+public interface GoogleAuthService {
+
+    URI generateGoogleAuthRedirectUrl(HttpServletRequest request, HttpServletResponse response);
+}

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -64,6 +64,10 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.amqp</groupId>
             <artifactId>spring-rabbit</artifactId>
         </dependency>

--- a/service/src/main/java/greencity/service/GoogleAuthServiceImpl.java
+++ b/service/src/main/java/greencity/service/GoogleAuthServiceImpl.java
@@ -24,7 +24,7 @@ public class GoogleAuthServiceImpl implements GoogleAuthService {
     @Value("${spring.security.oauth2.client.registration.google.scope}")
     private String scope;
 
-    @Value("${spring.security.oauth2.client.registration.google.authorization-grant-type}")
+    @Value("${spring.security.oauth2.client.registration.google.response-type}")
     private String responseType;
 
     @Value("${spring.security.oauth2.client.provider.google.authorization-uri}")

--- a/service/src/main/java/greencity/service/GoogleAuthServiceImpl.java
+++ b/service/src/main/java/greencity/service/GoogleAuthServiceImpl.java
@@ -1,0 +1,88 @@
+package greencity.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.security.SecureRandom;
+import java.util.*;
+
+@Service
+public class GoogleAuthServiceImpl implements GoogleAuthService {
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${spring.security.oauth2.client.registration.google.scope}")
+    private String scope;
+
+    @Value("${spring.security.oauth2.client.registration.google.authorization-grant-type}")
+    private String responseType;
+
+    @Value("${spring.security.oauth2.client.provider.google.authorization-uri}")
+    private String authorizationUri;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    private final AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
+
+    public GoogleAuthServiceImpl(
+            AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository) {
+        this.authorizationRequestRepository = authorizationRequestRepository;
+    }
+
+    private String getFormattedScope(String scope) {
+        return scope.replace(",", " ");
+    }
+
+    private String generateState() {
+        byte[] bytes = new byte[32];
+        secureRandom.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private OAuth2AuthorizationRequest buildAuthorizationRequest(String state) {
+        Map<String, Object> additionalParameters = new HashMap<>();
+        additionalParameters.put("access_type", "offline");
+
+        return OAuth2AuthorizationRequest.authorizationCode()
+                .clientId(clientId)
+                .redirectUri(redirectUri)
+                .scopes(Set.of(scope.split(",")))
+                .authorizationUri(authorizationUri)
+                .additionalParameters(additionalParameters)
+                .attributes(Collections.singletonMap(
+                        OAuth2ParameterNames.REGISTRATION_ID, "google"))
+                .state(state)
+                .build();
+    }
+
+    @Override
+    public URI generateGoogleAuthRedirectUrl(HttpServletRequest request, HttpServletResponse response) {
+        String state = generateState();
+
+        OAuth2AuthorizationRequest authorizationRequest = buildAuthorizationRequest(state);
+
+        authorizationRequestRepository.saveAuthorizationRequest(authorizationRequest, request, response);
+
+        String formattedScope = getFormattedScope(scope);
+
+        return UriComponentsBuilder.fromUriString(authorizationUri)
+                .queryParam(OAuth2ParameterNames.CLIENT_ID, clientId)
+                .queryParam(OAuth2ParameterNames.REDIRECT_URI, redirectUri)
+                .queryParam(OAuth2ParameterNames.SCOPE, formattedScope)
+                .queryParam(OAuth2ParameterNames.RESPONSE_TYPE, responseType)
+                .queryParam(OAuth2ParameterNames.STATE, state)
+                .encode()
+                .build()
+                .toUri();
+    }
+}

--- a/service/src/test/java/greencity/service/GoogleAuthServiceImplTest.java
+++ b/service/src/test/java/greencity/service/GoogleAuthServiceImplTest.java
@@ -1,0 +1,81 @@
+package greencity.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class GoogleAuthServiceImplTest {
+
+    @Mock
+    private AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private HttpServletResponse response;
+
+    @InjectMocks
+    private GoogleAuthServiceImpl googleAuthService;
+
+    private static final String CLIENT_ID = "dummy_client_id";
+    private static final String REDIRECT_URI = "http://localhost:8060/auth/google/callback";
+    private static final String SCOPE = "email,profile,openid";
+    private static final String RESPONSE_TYPE = "code";
+    private static final String AUTH_URI = "https://auth.google.com/auth";
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(googleAuthService, "clientId", CLIENT_ID);
+        ReflectionTestUtils.setField(googleAuthService, "redirectUri", REDIRECT_URI);
+        ReflectionTestUtils.setField(googleAuthService, "scope", SCOPE);
+        ReflectionTestUtils.setField(googleAuthService, "responseType", RESPONSE_TYPE);
+        ReflectionTestUtils.setField(googleAuthService, "authorizationUri", AUTH_URI);
+    }
+
+    @Test
+    @DisplayName("Returns correct URI for redirection + saves request to repository")
+    void generateGoogleAuthRedirectUrl_ReturnCorrectUrl_And_SaveRequest() {
+        URI url = googleAuthService.generateGoogleAuthRedirectUrl(request, response);
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUri(url);
+        Map<String, String> params = builder.build().getQueryParams().toSingleValueMap();
+
+        assertEquals(CLIENT_ID, params.get(OAuth2ParameterNames.CLIENT_ID));
+        assertEquals(REDIRECT_URI, params.get(OAuth2ParameterNames.REDIRECT_URI));
+        assertEquals(SCOPE.replace(",", "%20"), params.get(OAuth2ParameterNames.SCOPE));
+        assertEquals(RESPONSE_TYPE, params.get(OAuth2ParameterNames.RESPONSE_TYPE));
+
+        String state = params.get(OAuth2ParameterNames.STATE);
+        assertNotNull(state);
+
+        ArgumentCaptor<OAuth2AuthorizationRequest> authRequestCaptor =
+                ArgumentCaptor.forClass(OAuth2AuthorizationRequest.class);
+        verify(authorizationRequestRepository).saveAuthorizationRequest(
+                authRequestCaptor.capture(), eq(request), eq(response));
+
+        OAuth2AuthorizationRequest savedRequest = authRequestCaptor.getValue();
+        assertEquals(state, savedRequest.getState());
+    }
+}


### PR DESCRIPTION
Configured Google OAuth credentials.
And implemented OAuth initiation endpoint GET /auth/google, that redirects user to Google authorization page.
Also added unit test for GoogleAuthService.
Endpoint works correctly, redirects user to Google. Then google redirects user to auth/google/callback with data.
<img width="1051" height="609" alt="image" src="https://github.com/user-attachments/assets/1eaa3f32-6996-4aef-a61f-ba523c2abf8d" />
<img width="257" height="34" alt="image" src="https://github.com/user-attachments/assets/994c833b-43d1-4d59-9111-05d66c6bc639" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Google sign-in initiation endpoint that redirects users to the Google consent screen.
  - Added server-side support to build and persist Google OAuth2 authorization requests and produce redirect URLs.
- Security
  - Updated access rules to allow public access to the Google auth endpoint.
- Configuration
  - Added OAuth2 client settings and support for externalized secrets.
- Tests
  - Added unit tests covering the Google auth redirect flow.
- Chores
  - Added secret-related files to .gitignore to prevent accidental commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->